### PR TITLE
0.2.0: Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,10 @@
 [root]
 name = "rand-bytes"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -113,14 +113,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.7.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "untrusted"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -207,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c83adcb08e5b922e804fe1918142b422602ef11f2fd670b0b52218cb5984a20"
 "checksum rayon-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "767d91bacddf07d442fe39257bf04fd95897d1c47c545d009f6beb03efd038f8"
-"checksum ring 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6210568620e7b9d3f6e27f4bef63140cb88a15fbfb49b041bd3343b92c109166"
+"checksum ring 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "77b02add524c440119e5efd6659290d9d51835b6f989026b34b694ac35175fe0"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
@@ -215,7 +215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum untrusted 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "193df64312e3515fd983ded55ad5bcaa7647a035804828ed757e832ce6029ef3"
+"checksum untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b65243989ef6aacd9c0d6bd2b822765c3361d8ed352185a6f3a41f3a718c673"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand-bytes"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Yong Wen Chua <me@yongwen.xyz>"]
 license = "Apache-2.0"
 description = "A simple tool to generate cryptographically secure random bytes using a cryptographic pseudo-random number generator."
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 clap = "2.23.2"
 lazy_static = "0.2"
-ring = "0.7.5"
+ring = "0.9.4"
 
 [dev-dependencies]
 tempfile = "2.1.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{self, BufWriter, Write};
 
 use clap::{Arg, App};
-use ring::rand::SystemRandom;
+use ring::rand::{SecureRandom, SystemRandom};
 
 fn main() {
     let args = make_parser().get_matches();
@@ -43,7 +43,7 @@ fn make_parser<'a, 'b>() -> App<'a, 'b>
                  .index(1))
 }
 
-fn rng() -> &'static SystemRandom {
+fn rng() -> &'static SecureRandom {
     use std::ops::Deref;
 
     lazy_static! {


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.